### PR TITLE
Update Fetch.js to rethrow error

### DIFF
--- a/src/Fetch.js
+++ b/src/Fetch.js
@@ -84,6 +84,7 @@ export default class Fetch extends Component {
             this.props.onError(this.state.error)
           }
         })
+        throw error;
       })
     })
   }


### PR DESCRIPTION
Fetch is currently swallowing errors that occur in the child component. Although an `onError` callback exists, it's not practical to add callbacks to every Fetch instance, instead it would be better if Fetch allowed the error to continue to bubble up, and caught. If not caught, it should be allowed to surface completely which can in turn be snapped up by external logging tools like Loggly.