### PR TITLE
Support axios' `withCredentials` parameter

### DIFF
--- a/src/FetchService.js
+++ b/src/FetchService.js
@@ -17,7 +17,8 @@ class FetchService extends PureComponent {
     onResponse: PropTypes.func,
     onData: PropTypes.func,
     onError: PropTypes.func,
-    children: PropTypes.func
+    children: PropTypes.func,
+    withCredentials: PropTypes.bool
   }
 
   static defaultProps = {
@@ -85,7 +86,8 @@ class FetchService extends PureComponent {
       url: mergedProps.url,
       params: mergedProps.urlParams,
       headers: mergedProps.headers,
-      data: mergedProps.body
+      data: mergedProps.body,
+      withCredentials: mergedProps.withCredentials
     }).then(response => {
       if (this.willUnmount) {
         return


### PR DESCRIPTION
Only added the property mentioned in #35, but it's worth considering other [axios config params](https://github.com/mzabriskie/axios#request-config) which should be added to fetch's api (e.g. `timeout`)